### PR TITLE
rspec 3.0 compatibility

### DIFF
--- a/active_importer.gemspec
+++ b/active_importer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "< 3"
 
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "activerecord"

--- a/active_importer.gemspec
+++ b/active_importer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "< 3"
+  spec.add_development_dependency "rspec", ">= 2.2.0"
 
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "activerecord"

--- a/spec/active_importer/base_spec.rb
+++ b/spec/active_importer/base_spec.rb
@@ -23,7 +23,7 @@ describe ActiveImporter::Base do
   let(:importer) { EmployeeImporter.new('/dummy/file') }
 
   before do
-    allow(Roo::Spreadsheet).to receive(:open).at_least(:once).and_return { Spreadsheet.new(spreadsheet_data) }
+    allow(Roo::Spreadsheet).to receive(:open).at_least(:once).and_return Spreadsheet.new(spreadsheet_data)
     EmployeeImporter.instance_variable_set(:@fetch_model_block, nil)
     EmployeeImporter.instance_variable_set(:@sheet_index, nil)
     EmployeeImporter.transactional(false)


### PR DESCRIPTION
passing a block to `and_return` has been deprecated and was subsequently removed in rspec 3.0

I'll let you `git merge --squash` if you want this, rather than rebasing a pushed branch
