### PR TITLE
Allow unlabelled columns

### DIFF
--- a/lib/active_importer/base.rb
+++ b/lib/active_importer/base.rb
@@ -54,7 +54,7 @@ module ActiveImporter
     end
 
     def self.column(title, field = nil, options = nil, &block)
-      title = title.strip
+      title = title.to_s.strip unless title.is_a?(Integer)
       if columns[title]
         raise "Duplicate importer column '#{title}'"
       end
@@ -269,7 +269,7 @@ module ActiveImporter
     end
 
     def find_header_index
-      required_column_keys = columns.keys.reject { |title| columns[title][:optional] }
+      required_column_keys = columns.keys.reject { |title| title.is_a?(Integer) || columns[title][:optional] }
       (1..@book.last_row).each do |index|
         row = @book.row(index).map { |cell| cell.to_s.strip }
         return index if required_column_keys.all? { |item| row.include?(item) }
@@ -281,6 +281,7 @@ module ActiveImporter
       @header_index = find_header_index
       if @header_index
         @header = @book.row(@header_index).map(&:to_s).map(&:strip)
+        @header.map!.with_index{|label, i| label.empty? ? i : label }
       else
         raise 'Spreadsheet does not contain all the expected columns'
       end


### PR DESCRIPTION
I'm importing a few files with badly formed headers, but which are always laid out the same way (they're automatically generated). Most columns are named, but a few aren't.

This PR both allows empty cells in the header row, and allows these unnamed columns to be imported by integer. Test suite passes on rspec <= 2.99, but no new tests added yet. If this functionality is desirable to anyone else, I'll add them.
